### PR TITLE
Add iOS deep links with fallback in search app

### DIFF
--- a/GPTUSER/search-app/public/script.js
+++ b/GPTUSER/search-app/public/script.js
@@ -13,9 +13,18 @@ document.getElementById('searchBtn').addEventListener('click', async () => {
   data.results.forEach(r => {
     const li = document.createElement('li');
     const a = document.createElement('a');
-    a.href = r.url;
-    a.textContent = `${r.platform}：${r.url}`;
+    a.href = r.webUrl;
+    a.textContent = `${r.platform}：${r.webUrl}`;
     a.target = '_blank';
+    if (r.deepLink) {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        window.location.href = r.deepLink;
+        setTimeout(() => {
+          window.location.href = r.webUrl;
+        }, 1500);
+      });
+    }
     li.appendChild(a);
     list.appendChild(li);
   });

--- a/GPTUSER/search-app/server.js
+++ b/GPTUSER/search-app/server.js
@@ -7,20 +7,34 @@ const PORT = process.env.PORT || 3000;
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json());
 
-function buildSearchLink(platform, query) {
+// Build web and deep links for a platform search.
+// Detects iOS user agents to return a deep-link URL scheme
+// so the client can attempt to open the native app.
+function buildSearchLink(platform, query, userAgent = '') {
   const q = encodeURIComponent(query);
-  switch (platform) {
-    case 'xiaohongshu':
-      return `https://www.xiaohongshu.com/search_result?keyword=${q}`;
-    case 'baidu':
-      return `https://www.baidu.com/s?wd=${q}`;
-    case 'douyin':
-      return `https://www.douyin.com/search/${q}`;
-    case 'bilibili':
-      return `https://search.bilibili.com/all?keyword=${q}`;
-    default:
-      return '#';
-  }
+  const isIOS = /iPad|iPhone|iPod/.test(userAgent);
+
+  const webLinks = {
+    xiaohongshu: `https://www.xiaohongshu.com/search_result?keyword=${q}`,
+    baidu: `https://www.baidu.com/s?wd=${q}`,
+    douyin: `https://www.douyin.com/search/${q}`,
+    bilibili: `https://search.bilibili.com/all?keyword=${q}`,
+  };
+
+  // iOS deep-link schemes for each platform. These may only work on
+  // devices with the corresponding apps installed.
+  const deepLinks = {
+    xiaohongshu: `xiaohongshu://search/result?keyword=${q}`,
+    baidu: `baiduboxapp://s?word=${q}`,
+    douyin: `snssdk1128://search?keyword=${q}`,
+    bilibili: `bilibili://search?keyword=${q}`,
+  };
+
+  return {
+    platform,
+    webUrl: webLinks[platform] || '#',
+    deepLink: isIOS ? deepLinks[platform] || null : null,
+  };
 }
 
 app.post('/search', (req, res) => {
@@ -28,7 +42,8 @@ app.post('/search', (req, res) => {
   if (!query || !Array.isArray(platforms)) {
     return res.status(400).json({ error: 'Invalid request' });
   }
-  const results = platforms.map((p) => ({ platform: p, url: buildSearchLink(p, query) }));
+  const ua = req.headers['user-agent'] || '';
+  const results = platforms.map((p) => buildSearchLink(p, query, ua));
   res.json({ results });
 });
 


### PR DESCRIPTION
## Summary
- Detect iOS user agents on the server and return app deep links with web fallbacks
- Client attempts to open deep links and falls back to web URLs when apps are missing

## Testing
- `npm test`
- `curl -s -H 'Content-Type: application/json' -H 'User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1' -d '{"query":"test","platforms":["baidu","douyin"]}' http://localhost:3000/search`


------
https://chatgpt.com/codex/tasks/task_e_689329b644248331a89d5ef34f5b8ab5